### PR TITLE
Add a way to select backend type "overlayfs" or "bare"

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -5,7 +5,7 @@ deploy
 ------
 
 In order to spawn containers you need to play setup-site.yaml playbook.
-Ansible will setup all needed containers according to vars/hosts.yaml
+Ansible will setup all needed containers according to vars/config.yaml
 
 ```
 $ ansible-playbook -i /dev/null -l localhost setup-site.yaml

--- a/deploy/tasks/install_container.yaml
+++ b/deploy/tasks/install_container.yaml
@@ -5,12 +5,19 @@
 - name: "Create overlay workdir for container"
   file: path=/var/lib/overlay_dir/{{ item.key }}/workdir state=directory
   with_dict: arg
+  when: item.value.type == "overlayfs"
 - name: "Create overlay upperdir for container"
   file: path=/var/lib/overlay_dir/{{ item.key }}/upperdir state=directory
   with_dict: arg
+  when: item.value.type == "overlayfs"
 - name: "Mount rootfs"
   shell: mount -t overlay -o upperdir=/var/lib/overlay_dir/{{ item.key }}/upperdir,lowerdir=/var/cache/int_tests/bases/{{ item.value.base }},workdir=/var/lib/overlay_dir/{{ item.key }}/workdir overlayfs /var/lib/lxc/{{ item.key }}/rootfs
   with_dict: arg
+  when: item.value.type == "overlayfs"
+- name: "Copy rootfs"
+  shell: rsync -a /var/cache/int_tests/bases/{{ item.value.base }}/* /var/lib/lxc/{{ item.key }}/rootfs/
+  with_dict: arg
+  when: item.value.type == "bare"
 - name: "Copy default container config"
   copy: src=/etc/lxc/default.conf dest=/var/lib/lxc/{{ item.key }}/config
   with_dict: arg

--- a/deploy/tasks/remove_container.yaml
+++ b/deploy/tasks/remove_container.yaml
@@ -2,6 +2,12 @@
 - name: "Umount container rootfs"
   shell: umount /var/lib/lxc/{{ item.key }}/rootfs
   with_dict: arg
+  when: item.value.type == "overlayfs"
 - name: "Clean overlay"
   shell: rm -Rf /var/lib/overlay_dir/{{ item.key }}
   with_dict: arg
+  when: item.value.type == "overlayfs"
+- name: "Clean rootfs"
+  shell: rm -Rf /var/lib/lxc/{{ item.key }}/rootfs
+  with_dict: arg
+  when: item.value.type == "bare"

--- a/deploy/vars/config.yaml
+++ b/deploy/vars/config.yaml
@@ -9,16 +9,19 @@ site:
 hosts:
   puppetmaster:
     base: precise
+    type: overlayfs
     ip: 192.168.100.2
     user: ubuntu
     home: /home/ubuntu
   node1:
     base: precise
+    type: bare
     ip: 192.168.100.3
     user: ubuntu
     home: /home/ubuntu
   node2:
     base: trusty
+    type: overlayfs
     ip: 192.168.100.4
     user: root
     home: /root


### PR DESCRIPTION
If type is bare, the rootfs is a direct copy of the base
file tree instead of a overlayfs mount. In some case
I got some strange FS problems with overlayfs that disappeared
with a bare FS. So this patch add a switch to allow
use of both.
